### PR TITLE
Add authentication and RBAC for activity management

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Authentication with role-based access control (RBAC)
+- Sign up and unregister with role-aware permissions
 
 ## Getting Started
 
@@ -30,7 +31,20 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/auth/login`                                                     | Login and receive a bearer token                                    |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity (requires `Authorization: Bearer <token>`) |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from an activity (requires `Authorization: Bearer <token>`) |
+
+## Authentication and Roles
+
+The app uses token-based authentication via `/auth/login`.
+
+- Roles: `student`, `clubAdmin`, `hr`, `schoolAdmin`
+- Protected endpoints: signup and unregister
+- Students can only sign up/unregister themselves (email must match the logged-in student)
+- Admin roles can sign up/unregister any student email
+
+Sample users are stored in `users.json`.
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,15 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+import json
 import os
 from pathlib import Path
+import secrets
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +22,58 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+security = HTTPBearer(auto_error=False)
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class AuthenticatedUser(BaseModel):
+    username: str
+    email: str
+    role: str
+
+
+allowed_roles = {"student", "clubAdmin", "hr", "schoolAdmin"}
+
+
+def load_users() -> dict:
+    users_file_path = current_dir / "users.json"
+    with users_file_path.open("r", encoding="utf-8") as users_file:
+        return json.load(users_file)
+
+
+users = load_users()
+active_tokens = {}
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> AuthenticatedUser:
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+
+    token = credentials.credentials
+    username = active_tokens.get(token)
+
+    if username is None or username not in users:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+        )
+
+    user_record = users[username]
+    return AuthenticatedUser(
+        username=username,
+        email=user_record["email"],
+        role=user_record["role"],
+    )
 
 # In-memory activity database
 activities = {
@@ -88,9 +144,47 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def login(payload: LoginRequest):
+    user_record = users.get(payload.username)
+
+    if user_record is None or user_record.get("password") != payload.password:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid username or password",
+        )
+
+    role = user_record.get("role")
+    if role not in allowed_roles:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User role is not permitted",
+        )
+
+    token = secrets.token_urlsafe(32)
+    active_tokens[token] = payload.username
+
+    return {
+        "access_token": token,
+        "token_type": "bearer",
+        "role": role,
+        "email": user_record["email"],
+    }
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+):
     """Sign up a student for an activity"""
+    if current_user.role == "student" and email != current_user.email:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Students can only sign up themselves",
+        )
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +205,18 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    current_user: AuthenticatedUser = Depends(get_current_user),
+):
     """Unregister a student from an activity"""
+    if current_user.role == "student" and email != current_user.email:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Students can only unregister themselves",
+        )
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -13,6 +13,22 @@
     </header>
 
     <main>
+      <section id="auth-container">
+        <h3>Teacher/Admin Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="Enter username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="Enter password" />
+          </div>
+          <button type="submit">Login</button>
+        </form>
+        <p id="auth-status" class="info">Not logged in. Signup/unregister requires login.</p>
+      </section>
+
       <section id="activities-container">
         <h3>Available Activities</h3>
         <div id="activities-list">

--- a/src/users.json
+++ b/src/users.json
@@ -1,0 +1,22 @@
+{
+  "student_anna": {
+    "password": "student123",
+    "role": "student",
+    "email": "anna@mergington.edu"
+  },
+  "club_admin": {
+    "password": "clubadmin123",
+    "role": "clubAdmin",
+    "email": "club.admin@mergington.edu"
+  },
+  "hr_user": {
+    "password": "hr123",
+    "role": "hr",
+    "email": "hr@mergington.edu"
+  },
+  "school_admin": {
+    "password": "schooladmin123",
+    "role": "schoolAdmin",
+    "email": "admin@mergington.edu"
+  }
+}


### PR DESCRIPTION
## Summary
Implements issue #9 by adding authentication and role-based access control for activity management operations.

## Changes
- Add `POST /auth/login` endpoint that returns a bearer token
- Add token validation and current-user dependency in backend
- Protect signup/unregister endpoints with authentication
- Enforce RBAC rule: students can only manage their own email; admin roles can manage any student
- Add `src/users.json` with sample accounts and roles
- Update frontend with login form and bearer token usage for protected requests
- Update API documentation in `src/README.md`

## Notes
- This implementation uses in-memory token storage for simplicity.
- Intended to satisfy initial RBAC/auth requirements from issue #9.

Closes #9